### PR TITLE
Adding the ability to use command click to open the wiki instead of CTRL

### DIFF
--- a/src/components/checklist/CategoryItem.jsx
+++ b/src/components/checklist/CategoryItem.jsx
@@ -80,7 +80,8 @@ function CategoryItem({ name, item }) {
 					<Button
 						className="item-name"
 						onClick={e => {
-							// Meta is MacOS CMD key, ctrl + click on MacOS and chrome ends up in a 'right click' being sent.
+							// The meta key (MacOS command/⌘ key) is used as an alternative to the Ctrl key as
+							// default macOS settings convert Ctrl + Left Click to a Right Click.
 							if (e.ctrlKey || e.metaKey) {
 								window.open(
 									item.wiki ||

--- a/src/components/checklist/ItemGeneralInfoTooltip.jsx
+++ b/src/components/checklist/ItemGeneralInfoTooltip.jsx
@@ -7,8 +7,10 @@ import { PaginatedTooltipTitle } from "../PaginatedTooltip";
 import ItemComponent from "./ItemComponent";
 
 function ItemGeneralInfoTooltip({ item }) {
-	// Platform is soon to be deprecated but most browsers don't support new standard.
-	const isMacOS = window.navigator.platform == "MacIntel";
+	const isMacOS =
+		window.navigator.userAgentData?.platform === "macOS" ||
+		window.navigator.platform === "MacIntel"; //TODO: Remove usage of deprecated Navigator.platform
+
 	return (
 		<div className="item-tooltip">
 			<PaginatedTooltipTitle title="General Information" />
@@ -50,7 +52,7 @@ function ItemGeneralInfoTooltip({ item }) {
 				)}
 				{item.mr && <span>{`Mastery Rank ${item.mr}`}</span>}
 			</GluedComponents>
-			<span>{isMacOS ? "CMD" : "Ctrl"} + Left Click for Wiki</span>
+			<span>{isMacOS ? "Cmd" : "Ctrl"} + Left Click for Wiki</span>
 		</div>
 	);
 }


### PR DESCRIPTION
Adds the ability to use command click to open the wiki instead of control. Control click on macos ends up being sent as a right click.

Does use a deprecated JS API call, but the new API is not supported currently in a lot of browsers. 
See: https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData