### PR TITLE
Added "Hide Prime" toggle

### DIFF
--- a/src/components/checklist/CategoryInfo.jsx
+++ b/src/components/checklist/CategoryInfo.jsx
@@ -42,12 +42,10 @@ function CategoryItem({ name }) {
 	let totalXP = 0;
 	Object.entries(categoryItems).forEach(([itemName, item]) => {
 		if (
-			hideFounders &&
-			foundersItems.includes(itemName) &&
-			!itemsMastered.has(itemName)
+			!itemsMastered.has(itemName) &&
+			((hideFounders && foundersItems.includes(itemName)) ||
+				(hidePrime && itemIsPrime(itemName)))
 		)
-			return;
-		if (hidePrime && itemIsPrime(itemName) && !itemsMastered.has(itemName))
 			return;
 
 		totalCount++;

--- a/src/components/checklist/CategoryInfo.jsx
+++ b/src/components/checklist/CategoryInfo.jsx
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import { useStore } from "../../hooks/useStore";
-import { foundersItems } from "../../utils/items";
+import { foundersItems, itemIsPrime } from "../../utils/items";
 import { xpFromItem } from "../../utils/mastery-rank";
 import BaseCategoryInfo from "./BaseCategoryInfo";
 
@@ -24,12 +24,14 @@ function CategoryItem({ name }) {
 		itemsMastered,
 		partiallyMasteredItems,
 		categoryItems,
-		hideFounders
+		hideFounders,
+		hidePrime
 	} = useStore(state => ({
 		itemsMastered: state.itemsMastered,
 		partiallyMasteredItems: state.partiallyMasteredItems,
 		categoryItems: state.items[name],
-		hideFounders: state.hideFounders
+		hideFounders: state.hideFounders,
+		hidePrime: state.hidePrime
 	}));
 
 	let masteredCount = 0;
@@ -45,6 +47,13 @@ function CategoryItem({ name }) {
 			!itemsMastered.has(itemName)
 		)
 			return;
+		if (
+			hidePrime && 
+			itemIsPrime(itemName) &&
+			!itemsMastered.has(itemName)
+		)
+			return;
+		
 		totalCount++;
 		totalXP += xpFromItem(item, name);
 		if (itemsMastered.has(itemName)) {

--- a/src/components/checklist/CategoryInfo.jsx
+++ b/src/components/checklist/CategoryInfo.jsx
@@ -47,13 +47,9 @@ function CategoryItem({ name }) {
 			!itemsMastered.has(itemName)
 		)
 			return;
-		if (
-			hidePrime && 
-			itemIsPrime(itemName) &&
-			!itemsMastered.has(itemName)
-		)
+		if (hidePrime && itemIsPrime(itemName) && !itemsMastered.has(itemName))
 			return;
-		
+
 		totalCount++;
 		totalXP += xpFromItem(item, name);
 		if (itemsMastered.has(itemName)) {

--- a/src/components/checklist/CategoryItem.jsx
+++ b/src/components/checklist/CategoryItem.jsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useStore } from "../../hooks/useStore";
 import checkmark from "../../icons/checkmark.svg";
 import { SHARED } from "../../utils/checklist-types";
-import { foundersItems, itemShape } from "../../utils/items";
+import { foundersItems, itemShape, itemIsPrime } from "../../utils/items";
 import Button from "../Button";
 import PaginatedTooltip from "../PaginatedTooltip";
 import ItemGeneralInfoTooltip from "./ItemGeneralInfoTooltip";
@@ -28,9 +28,8 @@ function CategoryItem({ name, item }) {
 		setPartiallyMasteredItem: state.setPartiallyMasteredItem,
 		hidden:
 			(state.hideMastered && state.itemsMastered.has(name)) ||
-			(state.hideFounders &&
-				foundersItems.includes(name) &&
-				!state.itemsMastered.has(name))
+			(state.hideFounders && foundersItems.includes(name) && !state.itemsMastered.has(name)) ||
+			(state.hidePrime && itemIsPrime(name) && !state.itemsMastered.has(name))
 	}));
 	const [rankSelectToggled, setRankSelectToggled] = useState(false);
 

--- a/src/components/checklist/CategoryItem.jsx
+++ b/src/components/checklist/CategoryItem.jsx
@@ -28,8 +28,12 @@ function CategoryItem({ name, item }) {
 		setPartiallyMasteredItem: state.setPartiallyMasteredItem,
 		hidden:
 			(state.hideMastered && state.itemsMastered.has(name)) ||
-			(state.hideFounders && foundersItems.includes(name) && !state.itemsMastered.has(name)) ||
-			(state.hidePrime && itemIsPrime(name) && !state.itemsMastered.has(name))
+			(state.hideFounders &&
+				foundersItems.includes(name) &&
+				!state.itemsMastered.has(name)) ||
+			(state.hidePrime &&
+				itemIsPrime(name) &&
+				!state.itemsMastered.has(name))
 	}));
 	const [rankSelectToggled, setRankSelectToggled] = useState(false);
 
@@ -115,3 +119,4 @@ CategoryItem.propTypes = {
 };
 
 export default CategoryItem;
+

--- a/src/components/checklist/Checklist.jsx
+++ b/src/components/checklist/Checklist.jsx
@@ -1,6 +1,6 @@
 import Masonry from "react-masonry-css";
 import { useStore } from "../../hooks/useStore";
-import { foundersItems } from "../../utils/items";
+import { foundersItems,itemIsPrime } from "../../utils/items";
 import Category from "./Category";
 
 function Checklist() {
@@ -11,7 +11,8 @@ function Checklist() {
 				!Object.keys(state.items[category]).every(
 					item =>
 						state.itemsMastered.has(item) ||
-						(state.hideFounders && foundersItems.includes(item))
+						(state.hideFounders && foundersItems.includes(item)) ||
+						(state.hidePrime && itemIsPrime(item))
 				)
 			);
 		})

--- a/src/components/checklist/Checklist.jsx
+++ b/src/components/checklist/Checklist.jsx
@@ -1,6 +1,6 @@
 import Masonry from "react-masonry-css";
 import { useStore } from "../../hooks/useStore";
-import { foundersItems,itemIsPrime } from "../../utils/items";
+import { foundersItems, itemIsPrime } from "../../utils/items";
 import Category from "./Category";
 
 function Checklist() {
@@ -37,3 +37,4 @@ function Checklist() {
 }
 
 export default Checklist;
+

--- a/src/components/sidebar/Sidebar.jsx
+++ b/src/components/sidebar/Sidebar.jsx
@@ -44,3 +44,4 @@ function Sidebar() {
 }
 
 export default Sidebar;
+

--- a/src/components/sidebar/SidebarInputs.jsx
+++ b/src/components/sidebar/SidebarInputs.jsx
@@ -17,6 +17,8 @@ function SidebarInputs() {
 		setDrifterIntrinsics,
 		hideMastered,
 		setHideMastered,
+		hidePrime,
+		setHidePrime,
 		hideFounders,
 		setHideFounders,
 		displayingNodes,
@@ -31,6 +33,8 @@ function SidebarInputs() {
 		setDrifterIntrinsics: state.setDrifterIntrinsics,
 		hideMastered: state.hideMastered,
 		setHideMastered: state.setHideMastered,
+		hidePrime: state.hidePrime,
+		setHidePrime: state.setHidePrime,
 		hideFounders: state.hideFounders,
 		setHideFounders: state.setHideFounders,
 		displayingNodes: state.displayingNodes,
@@ -85,6 +89,11 @@ function SidebarInputs() {
 				label="Hide Mastered"
 				toggled={hideMastered}
 				onToggle={setHideMastered}
+			/>
+			<LabeledToggle
+				label="Hide Prime"
+				toggled={hidePrime}
+				onToggle={setHidePrime}
 			/>
 			{!displayingNodes && (
 				<LabeledToggle

--- a/src/hooks/useStore.js
+++ b/src/hooks/useStore.js
@@ -490,6 +490,8 @@ export const useStore = createWithEqualityFn(
 
 		hideMastered: true,
 		setHideMastered: firestoreFieldSetter("hideMastered"),
+		hidePrime: false,
+		setHidePrime: firestoreFieldSetter("hidePrime"),
 		hideFounders: true,
 		setHideFounders: firestoreFieldSetter("hideFounders"),
 

--- a/src/hooks/useStore.js
+++ b/src/hooks/useStore.js
@@ -427,7 +427,7 @@ export const useStore = createWithEqualityFn(
 								needsRounding.set(
 									componentName,
 									(needsRounding.get(componentName) ?? 0) +
-									componentCount
+										componentCount
 								);
 								return;
 							}
@@ -442,7 +442,8 @@ export const useStore = createWithEqualityFn(
 							ingredientId.includes("ArchwingRecipes") ||
 							ingredientId.includes("mechPart") ||
 							componentName.startsWith("Cortege") ||
-							componentName.startsWith("Morgha")) {
+							componentName.startsWith("Morgha")
+						) {
 							return;
 						}
 
@@ -465,7 +466,7 @@ export const useStore = createWithEqualityFn(
 						formaCost += Math.floor(
 							(item.maxLvl -
 								(partiallyMasteredItems[itemName] ?? 30)) /
-							2
+								2
 						);
 					}
 				}
@@ -640,3 +641,4 @@ function markMasteryChange(draftState, key, id, mastered) {
 		});
 	}
 }
+

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -22,3 +22,4 @@ function Login() {
 }
 
 export default Login;
+

--- a/src/pages/MasteryChecklist.jsx
+++ b/src/pages/MasteryChecklist.jsx
@@ -28,6 +28,7 @@ function MasteryChecklist(props) {
 		setRailjackIntrinsics,
 		setDrifterIntrinsics,
 		setHideMastered,
+		setHidePrime,
 		setHideFounders,
 		displayingNodes
 	} = useStore(state => ({
@@ -41,6 +42,7 @@ function MasteryChecklist(props) {
 		setRailjackIntrinsics: state.setRailjackIntrinsics,
 		setDrifterIntrinsics: state.setDrifterIntrinsics,
 		setHideMastered: state.setHideMastered,
+		setHidePrime: state.setHidePrime,
 		setHideFounders: state.setHideFounders,
 		displayingNodes: state.displayingNodes
 	}));
@@ -70,6 +72,7 @@ function MasteryChecklist(props) {
 				setRailjackIntrinsics(data?.intrinsics ?? 0, true);
 				setDrifterIntrinsics(data?.drifterIntrinsics ?? 0, true);
 				setHideMastered(data?.hideMastered ?? false, true);
+				setHidePrime(data?.hidePrime ?? false, true);
 				setHideFounders(data?.hideFounders ?? true, true);
 				setNodesMastered(data?.starChart ?? [], false);
 				setNodesMastered(data?.steelPath ?? [], true);

--- a/src/pages/MasteryChecklist.jsx
+++ b/src/pages/MasteryChecklist.jsx
@@ -120,3 +120,4 @@ MasteryChecklist.propTypes = {
 };
 
 export default MasteryChecklist;
+

--- a/src/utils/items.js
+++ b/src/utils/items.js
@@ -6,7 +6,7 @@ export const foundersItems = ["Excalibur Prime", "Skana Prime", "Lato Prime"];
 
 export function itemIsPrime(name)
 {
-	return name.includes(" Prime") && !foundersItems.includes(name);
+	return (name.includes(" Prime") || name.includes("Prime ")) && !foundersItems.includes(name);
 }
 
 export function getComponentImageUrl(id) {

--- a/src/utils/items.js
+++ b/src/utils/items.js
@@ -4,13 +4,19 @@ export const SCHEMA_VERSION = 3;
 
 export const foundersItems = ["Excalibur Prime", "Skana Prime", "Lato Prime"];
 
-export function itemIsPrime(name)
-{
-	return (name.endsWith(" Prime") || name.startsWith("Prime ")) && !foundersItems.includes(name);
+export function itemIsPrime(name) {
+	return (
+		(name.endsWith(" Prime") || name.startsWith("Prime ")) &&
+		!foundersItems.includes(name)
+	);
 }
 
 export function getComponentImageUrl(id) {
-	return "https://cdn.jsdelivr.net/gh/Aericio/warframe-exports-data/image/" + id.slice(1).replaceAll("/", ".") + ".png";
+	return (
+		"https://cdn.jsdelivr.net/gh/Aericio/warframe-exports-data/image/" +
+		id.slice(1).replaceAll("/", ".") +
+		".png"
+	);
 }
 
 export const relicTiers = ["Lith", "Meso", "Neo", "Axi", "Requiem"];
@@ -32,3 +38,4 @@ export const itemShape = {
 	baro: PropTypes.arrayOf(PropTypes.number),
 	description: PropTypes.string
 };
+

--- a/src/utils/items.js
+++ b/src/utils/items.js
@@ -6,7 +6,7 @@ export const foundersItems = ["Excalibur Prime", "Skana Prime", "Lato Prime"];
 
 export function itemIsPrime(name)
 {
-	return (name.includes(" Prime") || name.includes("Prime ")) && !foundersItems.includes(name);
+	return (name.endsWith(" Prime") || name.startsWith("Prime ")) && !foundersItems.includes(name);
 }
 
 export function getComponentImageUrl(id) {

--- a/src/utils/items.js
+++ b/src/utils/items.js
@@ -4,6 +4,11 @@ export const SCHEMA_VERSION = 3;
 
 export const foundersItems = ["Excalibur Prime", "Skana Prime", "Lato Prime"];
 
+export function itemIsPrime(name)
+{
+	return name.includes(" Prime") && !foundersItems.includes(name);
+}
+
 export function getComponentImageUrl(id) {
 	return "https://cdn.jsdelivr.net/gh/Aericio/warframe-exports-data/image/" + id.slice(1).replaceAll("/", ".") + ".png";
 }


### PR DESCRIPTION
Adding this capability to resolve #276, this allows users to hide Prime items if they like. 

The implementation follows the same logic as hiding Founders items, but does not touch that logic - the user can hide all Primes but still include Founders, if they choose to.

The criteria for an item to be classified as Prime is the name containing " Prime" - including the space, in case DE decides to add a weapon called something like Primeval 🙂

Same hooks into Firebase applied as the other toggles.

### Toggled off (Include Prime):
![image](https://github.com/user-attachments/assets/a57555a3-35a2-4ea1-9fde-277ce9faad1d)

### Toggled on (Hide Prime):
![image](https://github.com/user-attachments/assets/ba00e903-df42-4002-a98e-5c8119bb06de)

### Hide Prime, Include Founders:
![image](https://github.com/user-attachments/assets/dcf30cdb-99e6-4efd-8eb1-069d35a36ce6)
