### PR TITLE
feat: use 32x32 icons instead of full-res

### DIFF
--- a/src/utils/items.js
+++ b/src/utils/items.js
@@ -13,7 +13,7 @@ export function itemIsPrime(name) {
 
 export function getComponentImageUrl(id) {
 	return (
-		"https://cdn.jsdelivr.net/gh/Aericio/warframe-exports-data/image/" +
+		"https://cdn.jsdelivr.net/gh/Aericio/warframe-exports-data/image/32x32/" +
 		id.slice(1).replaceAll("/", ".") +
 		".png"
 	);


### PR DESCRIPTION
- Use 32x32 icons instead of the full-res 512x512 icons.
- Observed roughly 5x decrease in data usage

On a new load without cache and loading "show crafting components" (previously):
![image](https://github.com/user-attachments/assets/91aa9aca-0afd-4646-8a16-949c8e5cb558)

On a new load without cache (now):
![image](https://github.com/user-attachments/assets/e0bf3858-7d64-45e7-a6a1-d24d7c4f5c57)

