### PR TITLE
feat: use new origin proxy url

### DIFF
--- a/.github/workflows/update-items.yml
+++ b/.github/workflows/update-items.yml
@@ -33,7 +33,8 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
           DISCORD_ADMIN_IDS: ${{ secrets.DISCORD_ADMIN_IDS }}
           FORCE_UPLOAD: ${{ contains(github.event.head_commit.message, 'force upload') && github.event_name == 'push' }}
-          PROXY_AUTH: ${{ secrets.PROXY_AUTH }}
+          WARFRAME_ORIGIN_PROXY: ${{ secrets.WARFRAME_ORIGIN_PROXY }}
+          X_PROXY_TOKEN: ${{ secrets.X_PROXY_TOKEN }}
       - name: Authenticate Firebase
         uses: 'google-github-actions/auth@v2'
         with:


### PR DESCRIPTION
Current proxy appears to have been blocked by Warframe. This PR replaces the current origin proxy and adds additional error handling to `fetchEndpoints()`.

## Environment Variables
- `WARFRAME_ORIGIN_PROXY`
-  `X-Proxy-Token` replacing `PROXY_AUTH`

Repository secrets have already been updated. 